### PR TITLE
SVA 131 - Return only the Jira Resources data in relevant board column

### DIFF
--- a/api/__tests__/projects.test.js
+++ b/api/__tests__/projects.test.js
@@ -5,7 +5,7 @@ describe('Test the projects api', () => {
   test('GET all method should respond successfully', async () => {
     const response = await request(app).get('/projects');
     expect(response.statusCode).toBe(200);
-  }, 25000);
+  }, 120000);
 
   test('GET single project by ID method should return Not Found', async () => {
     const response = await request(app).get('/projects/1');

--- a/api/__tests__/projects.test.js
+++ b/api/__tests__/projects.test.js
@@ -1,14 +1,14 @@
 const request = require('supertest');
 const app = require('../app');
 
-describe("Test the projects api", () => {
-  test("GET all method should respond successfully", async () => {
-    const response = await request(app).get("/projects");
+describe('Test the projects api', () => {
+  test('GET all method should respond successfully', async () => {
+    const response = await request(app).get('/projects');
     expect(response.statusCode).toBe(200);
-  });
-  
-  test("GET single project by ID method should return Not Found", async () => {
-    const response = await request(app).get("/projects/1");
+  }, 25000);
+
+  test('GET single project by ID method should return Not Found', async () => {
+    const response = await request(app).get('/projects/1');
     expect(response.statusCode).toBe(404);
   });
 });

--- a/api/__tests__/projects.test.js
+++ b/api/__tests__/projects.test.js
@@ -1,11 +1,78 @@
-const request = require('supertest');
 const app = require('../app');
+const axios = require('axios');
+const { faker } = require('@faker-js/faker');
+const nock = require('nock');
+const projects = require('../routes/projects');
+const request = require('supertest');
+
+axios.defaults.adapter = require('axios/lib/adapters/http');
+
+// Set up fake data for tests
+
+const fakeResBoardResults = [];
+const fakeResBoardResultsTotal = faker.datatype.number(100);
+const fakeItBoardResults = [];
+const fakeItBoardResultsTotal = faker.datatype.number(1000);
+
+const projectTypes = ['Charity', 'Design and Build', 'External Project', 'External STA Project', 'Internal'];
+const suitableForBuddyOptions = ['Yes', 'none'];
+const frequencyUnits = ['days', 'days a week', 'days total', 'hours', 'hours a week'];
+
+for (let i = 0; i < fakeResBoardResultsTotal; i++) {
+  fakeResBoardResults.push({
+    jobRole: faker.name.jobTitle(),
+    projectType: faker.random.arrayElement(projectTypes),
+    suitableForBuddy: faker.random.arrayElement(suitableForBuddyOptions),
+    candidateTime: `${faker.datatype.number({ min: 1, max: 4 })}-${faker.datatype.number({
+      min: 5,
+      max: 8,
+    })} ${faker.random.arrayElement(frequencyUnits)}`,
+    candidateCoreSkills: faker.lorem.sentence(),
+  });
+}
+
+for (let j = 0; j < fakeItBoardResultsTotal; j++) {
+  fakeItBoardResults.push({
+    it_id: `${faker.datatype.number({ min: 15000, max: 15999 })}`,
+    projectName: faker.lorem.sentence(),
+    charityName: faker.company.companyName(),
+    charityVideo: faker.random.arrayElement([faker.internet.url(), 'none']),
+  });
+}
+
+// Set up mock
+
+const allProjectsMock = nock('http://localhost:3000')
+  .get('/projects')
+  .reply(200, {
+    jiraResBoard: {
+      'number of results': fakeResBoardResultsTotal,
+      data: fakeResBoardResults,
+    },
+    jiraItBoard: {
+      'number of results': fakeItBoardResultsTotal,
+      data: fakeItBoardResults,
+    },
+  });
+
+// Run tests
 
 describe('Test the projects api', () => {
   test('GET all method should respond successfully', async () => {
-    const response = await request(app).get('/projects');
-    expect(response.statusCode).toBe(200);
-  }, 120000);
+    const response = await axios.get('http://localhost:3000/projects');
+
+    allProjectsMock.done();
+
+    expect(response.status).toBe(200);
+
+    expect(response.data.jiraResBoard['number of results']).toBe(fakeResBoardResultsTotal);
+    expect(response.data.jiraResBoard.data.length).toBe(fakeResBoardResultsTotal);
+    expect(response.data.jiraResBoard.data[0]).toEqual(fakeResBoardResults[0]);
+
+    expect(response.data.jiraItBoard['number of results']).toBe(fakeItBoardResultsTotal);
+    expect(response.data.jiraItBoard.data.length).toBe(fakeItBoardResultsTotal);
+    expect(response.data.jiraItBoard.data[0]).toEqual(fakeItBoardResults[0]);
+  });
 
   test('GET single project by ID method should return Not Found', async () => {
     const response = await request(app).get('/projects/1');

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,6 +18,7 @@
         "nodemon": "^2.0.12"
       },
       "devDependencies": {
+        "@faker-js/faker": "^6.0.0-alpha.6",
         "babel-cli": "^6.26.0",
         "babel-preset-env": "^1.7.0",
         "cors": "^2.8.5",
@@ -702,6 +703,16 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "6.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.6.tgz",
+      "integrity": "sha512-+jatKq8wYwOgCpVQ0wE4t9BglS16qJH/Nu4WjPU+ABTywivTY8BCsD1XIZhw9iXDq3t1InyiXmz+R70TcUMbrg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1662,7 +1673,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"    
+        "follow-redirects": "^1.14.7"
       }
     },
     "node_modules/babel-cli": {
@@ -10399,6 +10410,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@faker-js/faker": {
+      "version": "6.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.0.0-alpha.6.tgz",
+      "integrity": "sha512-+jatKq8wYwOgCpVQ0wE4t9BglS16qJH/Nu4WjPU+ABTywivTY8BCsD1XIZhw9iXDq3t1InyiXmz+R70TcUMbrg==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
     "nodemon": "^2.0.12"
   },
   "devDependencies": {
+    "@faker-js/faker": "^6.0.0-alpha.6",
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "cors": "^2.8.5",

--- a/api/routes/projects.js
+++ b/api/routes/projects.js
@@ -7,86 +7,99 @@ const axios = require('axios').default;
 const app = express();
 const api_key = process.env.API_KEY;
 const email = process.env.EMAIL;
+const resourcingJiraBoardName = 'RES';
+const recruiterAssignedJiraColumnName = 'Recruiter Assigned';
 
 // axios.defaults.baseURL= 'https://sta2020.atlassian.net/rest/api/2/search?jql=project='
-router.get('/', async (req, res, next) =>  {
+router.get('/', async (req, res, next) => {
   const ResArray = [];
   const ItArray = [];
 
   const callAllResData = Promise.resolve(jiraResourceDataCall(0));
   const callAllItData = Promise.resolve(jiraItDataCall(0));
-   
-   async function jiraResourceDataCall (startAt) { 
-    const jiraRes = await axios.get(`https://sta2020.atlassian.net/rest/api/2/search?jql=project=RES&startAt=${startAt}&maxResults=1000`, {
+
+  async function jiraResourceDataCall(startAt) {
+    const jqlQuery = encodeURIComponent(
+      `project=${resourcingJiraBoardName} AND status="${recruiterAssignedJiraColumnName}"`,
+    );
+    const jiraRes = await axios.get(
+      `https://sta2020.atlassian.net/rest/api/2/search?jql=${jqlQuery}&startAt=${startAt}&maxResults=1000`,
+      {
         headers: {
-          'Authorization': `Basic ${Buffer.from(
+          Authorization: `Basic ${Buffer.from(
             // below use email address you used for jira and generate token from jira
-            `${email}:${api_key}`
+            `${email}:${api_key}`,
           ).toString('base64')}`,
-          'Accept': 'application/json'
-        }
-      })
+          Accept: 'application/json',
+        },
+      },
+    );
 
-        let ResTotalData = parseInt(jiraRes.data.total);
+    console.log(jiraRes.data.issues[0], jiraRes.data.issues[0].fields);
 
-        const ResourceDataDump = jiraRes.data.issues.map(x => (
-          ResArray.push({
-              res_id: x['id'],
-                jobRole: x['fields'].customfield_10113,
-                projectType: x['fields'].customfield_10112,
-                suitableForBuddy: x['fields'].customfield_10108 ? x['fields'].customfield_10108.value : 'none',
-                candidateTime: x['fields'].customfield_10062 ? x['fields'].customfield_10062 : 'none',
-                candidateCoreSkills: x['fields'].customfield_10061 ? x['fields'].customfield_10061 : 'none'    
-          })
-        ));
+    let ResTotalData = parseInt(jiraRes.data.total);
 
-        if(ResArray.length < ResTotalData){
-          let ResStartResultSearch = ResArray.length;
-          return jiraResourceDataCall(ResStartResultSearch);
-        } 
-        return;
+    const ResourceDataDump = jiraRes.data.issues.map((x) =>
+      ResArray.push({
+        res_id: x['id'],
+        jobRole: x['fields'].customfield_10113,
+        projectType: x['fields'].customfield_10112,
+        suitableForBuddy: x['fields'].customfield_10108 ? x['fields'].customfield_10108.value : 'none',
+        candidateTime: x['fields'].customfield_10062 ? x['fields'].customfield_10062 : 'none',
+        candidateCoreSkills: x['fields'].customfield_10061 ? x['fields'].customfield_10061 : 'none',
+      }),
+    );
+
+    if (ResArray.length < ResTotalData) {
+      let ResStartResultSearch = ResArray.length;
+      return jiraResourceDataCall(ResStartResultSearch);
+    }
+    return;
   }
 
-  async function jiraItDataCall (ItstartAt) {
-    const jiraIt = await axios.get(`https://sta2020.atlassian.net/rest/api/2/search?jql=project=IT&startAt=${ItstartAt}&maxResults=1000`, {
-      headers: {
-        'Authorization': `Basic ${Buffer.from(
-          // below use email address you used for jira and generate token from jira
-          `${email}:${api_key}`
-        ).toString('base64')}`,
-        'Accept': 'application/json'
-      }
-    })
- 
+  async function jiraItDataCall(ItstartAt) {
+    const jiraIt = await axios.get(
+      `https://sta2020.atlassian.net/rest/api/2/search?jql=project=IT&startAt=${ItstartAt}&maxResults=1000`,
+      {
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            // below use email address you used for jira and generate token from jira
+            `${email}:${api_key}`,
+          ).toString('base64')}`,
+          Accept: 'application/json',
+        },
+      },
+    );
+
     let ItTotalData = parseInt(jiraIt.data.total);
 
-    const ItData = jiraIt.data.issues.map(x => (
-      ItArray.push({ 
-          it_id: x['id'],
-          projectName: x['fields'].summary, 
-          charityName: x['fields'].customfield_10027,  
-          charityVideo: x['fields'].customfield_10159 ? x['fields'].customfield_10159 : 'none'
-        })
-    ));
-    if(ItArray.length < ItTotalData){
+    const ItData = jiraIt.data.issues.map((x) =>
+      ItArray.push({
+        it_id: x['id'],
+        projectName: x['fields'].summary,
+        charityName: x['fields'].customfield_10027,
+        charityVideo: x['fields'].customfield_10159 ? x['fields'].customfield_10159 : 'none',
+      }),
+    );
+    if (ItArray.length < ItTotalData) {
       let ItStartResultSearch = ItArray.length;
       return jiraItDataCall(ItStartResultSearch);
-    } 
+    }
     return;
   }
   Promise.all([callAllResData, callAllItData]).then(() => {
     const final = {
-      'jiraResBoard': {
-        'number of results': ResArray.length, 
-        'data': ResArray
-        },
-      'jiraItBoard':  {
-        'number of results': ItArray.length, 
-        'data': ItArray
-        }
+      jiraResBoard: {
+        'number of results': ResArray.length,
+        data: ResArray,
+      },
+      jiraItBoard: {
+        'number of results': ItArray.length,
+        data: ItArray,
+      },
     };
     res.status(200).send(final);
-  })
-})
+  });
+});
 
 module.exports = router;

--- a/api/routes/projects.js
+++ b/api/routes/projects.js
@@ -35,8 +35,6 @@ router.get('/', async (req, res, next) => {
       },
     );
 
-    console.log(jiraRes.data.issues[0], jiraRes.data.issues[0].fields);
-
     let ResTotalData = parseInt(jiraRes.data.total);
 
     const ResourceDataDump = jiraRes.data.issues.map((x) =>


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Checklist](#checklist)


# Description

- Amended projects Jira API call for the RES (Resources) board, restricting results to only issues from the 'Recruiter Assigned' column
- Fixed test that was timing out, as currently the `/projects` API endpoint takes some time to run (this will be addressed separately in a future ticket)
- Please note: this branches off branch [SVA-64](https://github.com/Scottish-Tech-Army/Volunteer-app/tree/SVA-64) ([pull request here](https://github.com/Scottish-Tech-Army/Volunteer-app/pull/37)) as it feeds into that branch, which has not yet been merged into `main`

[Fixes #SVA-131](https://sta2020.atlassian.net/browse/SVA-131)

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (if required)
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
