### PR TITLE
SVA-178 | Fix missing hours on some projects

### DIFF
--- a/api/cache/projects.js
+++ b/api/cache/projects.js
@@ -220,7 +220,7 @@ async function getResourcesFromJira(startAt, resArray) {
       type: x['fields'].customfield_10112,
       role: x['fields'].customfield_10113,
       skills: x['fields'].customfield_10061 ?? '',
-      hours: x['fields'].customfield_10062 ?? '',
+      hours: x['fields'].customfield_10165?.value ?? x['fields'].customfield_10062 ?? '',
       required: 1, // currently hardcoded as cannot see number of people coming back in Jira results
       buddying: x['fields'].customfield_10108 ? x['fields'].customfield_10108.value.toLowerCase() === 'yes' : false,
     }),

--- a/api/cache/projects.js
+++ b/api/cache/projects.js
@@ -220,7 +220,7 @@ async function getResourcesFromJira(startAt, resArray) {
       type: x['fields'].customfield_10112,
       role: x['fields'].customfield_10113,
       skills: x['fields'].customfield_10061 ?? '',
-      hours: x['fields'].customfield_10165?.value ?? x['fields'].customfield_10062 ?? '',
+      hours: x['fields'].customfield_10165?.value ?? x['fields'].customfield_10062 ?? '', // customfield_10165 is the newer field, customfield_10062 may not be needed in the future
       required: 1, // currently hardcoded as cannot see number of people coming back in Jira results
       buddying: x['fields'].customfield_10108 ? x['fields'].customfield_10108.value.toLowerCase() === 'yes' : false,
     }),


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
  - [Testing](#testing)
- [Checklist](#checklist)


# Description

- Hours information (time needed from a volunteer) was missing from some projects being returned by our API
- An example project where this has been happening is [Lower Impact living CIC - Database for reuse/recycle purposes](https://sta2020.atlassian.net/browse/RES-555) [http://localhost:3000/projects/single?res=15676&it=IT-577](http://localhost:3000/projects/single?res=15676&it=IT-577) (hours will now show up as I've updated the AirTable database)
- This was happening because a new field is now being used in Jira for project hours (the new Jira field is different -- I think it's a dropdown not free text any more -- which is why someone had to create it as a new field) but our API didn't know to check this field
- There are also still some projects in Jira using an older field for hours
- So for now we need to check both fields in order to make sure we get the project hours

Fixes [SVA-178](https://sta2020.atlassian.net/jira/software/projects/SVA/boards/145?selectedIssue=SVA-178)

## Testing

- To run the projects caching script which uses this code (as part of getting data back from the Jira API), in a terminal window go to the `api` directory, then run the command `node cache/run-projects.js`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
