### PR TITLE
Remove the network security config for debug builds

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -129,8 +129,8 @@ android {
         applicationId "org.scottishtecharmy.volunteerapp"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 3
-        versionName "1.0.2"
+        versionCode 4
+        versionName "1.0.3"
     }
     splits {
         abi {

--- a/app/android/app/src/debug/AndroidManifest.xml
+++ b/app/android/app/src/debug/AndroidManifest.xml
@@ -7,7 +7,8 @@
     <application
             android:usesCleartextTraffic="true"
             tools:targetApi="28"
-            tools:ignore="GoogleAppIndexingWarning">
+            tools:ignore="GoogleAppIndexingWarning"
+            tools:remove="android:networkSecurityConfig">
         <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>
 </manifest>

--- a/app/android/fastlane/metadata/android/en-GB/changelogs/4.txt
+++ b/app/android/fastlane/metadata/android/en-GB/changelogs/4.txt
@@ -1,0 +1,1 @@
+Change the welcome message on the loading screen

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "STA Volunteer app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Checklist](#checklist)


# Description

- I'm getting the following error when trying to run the app in the Android emulator:
![err3](https://user-images.githubusercontent.com/13078984/180390303-e9d194c9-d025-4d9b-ab5c-922826531ae0.PNG)
- Metro is running but the app can't connect to it because the config in `app/android/app/src/main/res/xml/network_security_config.xml` doesn't permit the connection
- For debug builds only, this change removes the android:networkSecurityConfig attribute; we need to keep it in for builds that are released to the Play Store.

## Type of change

Please delete options that are not relevant
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New Feature (non-breaking change which adds functionality)
- [] Breaking change(fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
