### PR TITLE
Make the linting CI ignore deleted files

### DIFF
--- a/.github/workflows/ci_app.yml
+++ b/.github/workflows/ci_app.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Run ESLint with extended checks
         working-directory: ./app
         # Run ESLint only on files that
-        # - have changed in this branch vs the current tip of the main branch
+        # - have changed in this branch vs the current tip of the main branch, and have not been deleted in this branch (--diff-filter)
         # - are in the current working directory (./app)
         # - have extensions .js, .jsx, .ts, .tsx
         # The file paths need to be supplied relative to the ./app directory because that's where ESLint runs. By default, the git diff command gives them relative to the repo root; --relative makes them relative to the current working directory.
-        run: npx eslint $(git diff --name-only --relative origin/main HEAD . | grep -E '\.(js|jsx|ts|tsx)$'| xargs) -c .eslintrc.ci.js
+        run: npx eslint $(git diff --name-only --relative --diff-filter=ACMRTUXB origin/main HEAD . | grep -E '\.(js|jsx|ts|tsx)$'| xargs) -c .eslintrc.ci.js


### PR DESCRIPTION
Should fix the issue that @joefhall is having whereby ESLint is trying to lint a deleted file. Adding the --diff-filter option removes deleted files from the list returned by git diff.

The command `git diff --name-only --relative --diff-filter=ACMRTUXB origin/main HEAD .` generates a list of files that have changed in the current branch vs the tip of main, *and which have not been deleted in the current branch*. This list is then filtered for relevant file extensions (the grep part of the command in ci_app.yml) and then passed to ESLint.

Sorry for not catching this the first time around!!

- [Description](#description)
  - [Type of change](#type-of-change)
- [Checklist](#checklist)


# Description

- Please include a summary of the change and which issue is fixed.
- List any dependencies that are required for this change.

Fixes # (issue number)

## Type of change

Please delete options that are not relevant
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New Feature (non-breaking change which adds functionality)
- [] Breaking change(fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation (if required)
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
