### PR TITLE
SVA-245 | Enforce app using https connection to API, remove insecure http connect

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,7 +40,7 @@ In the volapp-dev-test account, an [Elastic Beanstalk](https://eu-west-2.console
 
 You can connect your app to this environment by changing STA_BASE_URL to the load balancer address in `Volunteer-app/app/src/Config/index.ts`:
 
-` STA_BASE_URL: 'http://volunteerapp-env.eba-ivfm2tgp.eu-west-2.elasticbeanstalk.com',`
+` STA_BASE_URL: 'https://the-sta.com',`
 
 Note - as we move this into IaC and set up some build pipelines, things like env names, app names, domain names, IP Addresses will probably change.
 
@@ -62,13 +62,8 @@ E.g. `cp Volunteer-app/api/.env volunteer-app-aws-deployment/api/.env` (but this
 9. In the [Volunteer App Application versions](https://eu-west-2.console.aws.amazon.com/elasticbeanstalk/home?region=eu-west-2#/application/versions?applicationName=volunteer-app), Upload the myapp.zip that you created in step 6.
 10. Now select the version label you've just created and then select Action > Deploy
 11. Go to the environment dashboard and check the version label has updated and the Health is OK. If not, check the Logs (menu on the left hand side) or ask someone else in the team for help.
-12. Also check one of the API endpoints to make sure it's working, e.g. `http://volunteerapp-env.eba-ivfm2tgp.eu-west-2.elasticbeanstalk.com/projects` or `http://18.134.220.155/projects` -- at least one of these should work.
+12. Also check one of the API endpoints to make sure it's working, e.g. `https://the-sta.com/projects` or `https://the-sta.com/events` -- at least one of these should work.
 13. Delete the new directory containing copy of the repo you made in step 2 and everything in it, e.g. `rm -rf volunteer-app-aws-deployment/`
-
-## Known issues
-
-- The iOS simulator only works with the IP Address of the Load Balancer as the value of STA_BASE_URL:
-  - ` STA_BASE_URL: 'http://18.134.220.155',`
 
 # App deployment
 

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
-      android:theme="@style/SplashTheme"
-      android:networkSecurityConfig="@xml/network_security_config">
+      android:theme="@style/SplashTheme">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/app/android/app/src/main/res/xml/network_security_config.xml
+++ b/app/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">volunteerapp-env.eba-ivfm2tgp.eu-west-2.elasticbeanstalk.com</domain>
-    </domain-config>
-</network-security-config>

--- a/app/ios/STA/Info.plist
+++ b/app/ios/STA/Info.plist
@@ -26,19 +26,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>volunteerapp-env.eba-ivfm2tgp.eu-west-2.elasticbeanstalk.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string/>

--- a/app/src/Config/index.example.ts
+++ b/app/src/Config/index.example.ts
@@ -1,3 +1,7 @@
+/**
+ * @file Example config settings -- duplicate this file and create an index.ts file in the same directory.
+ */
+
 export const Config = {
   // This will eventually be what the STA_BASE_URL is. The API_URL
   // it is set to an empty string so we can use both for now.

--- a/app/src/Config/index.example.ts
+++ b/app/src/Config/index.example.ts
@@ -6,5 +6,6 @@ export const Config = {
   EXAMPLE_USER_URL: 'https://jsonplaceholder.typicode.com',
   // STA Base API URL (localhost may not work on Android as it points to
   // the local device, you can try using your local IP address instead)
-  STA_BASE_URL: 'http://localhost:5000',
+  STA_BASE_URL: 'http://localhost:3000',
+  // STA_BASE_URL: 'https://the-sta.com', // use this instead of your local API URL when you want to access the production API
 }


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- Previously we didn't have the production API running over https, now we do
- When we only had the API running over http, we added some security exceptions to allow the app to connect over http, but these aren't good to have in production and could lead to our app being rejected by the Google Play Store and/or App Store
- Updated the app to remove the http exception (except it should still work for accessing your API running locally in development, all being well) and enforce https (for iOS changes I followed [the recommendation here](https://stackoverflow.com/questions/38501012/is-it-safe-to-add-localhost-to-app-transport-security-ats-nsexceptiondomains))

Fixes # SVA-245

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Testing locally

- **Android:** run the emulator and please check that you can still access your local API over http (like normal when you're developing)
- **iOS - at least one reviewer with iOS emulator needed:** run the emulator and please check that you can still access your local API over http (like normal when you're developing).  I haven't been able to test this myself, so if there are issues it's important we catch them and can update the code in this PR.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have removed any unnecessary comments or console logging
- [x] I have made corresponding changes to the documentation (if required)
- [] I have addressed accessibility, if needed
- [x] I have followed best practices, e.g. NativeBase approaches and theming
- [] I have checked the app in dark mode, if making front-end design changes
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
