### PR TITLE
SVA-304 | Reduce crashes on project detail screen on Android when there's a video

### DIFF
--- a/app/src/NativeBase/Components/Video.tsx
+++ b/app/src/NativeBase/Components/Video.tsx
@@ -4,7 +4,8 @@
 
 import { navigate, RootStackParamList } from '@/Navigators/utils'
 import { Box, Image, Pressable } from 'native-base'
-import React, { FC, useState } from 'react'
+import React, { FC, useEffect, useState } from 'react'
+import { Dimensions, Platform } from 'react-native'
 import WebView from 'react-native-webview'
 import VideoPlaceholder from '../Assets/Images/video-placeholder.png'
 
@@ -35,13 +36,23 @@ const Video: FC<VideoProps> = ({
   videoWebpageScreen,
 }) => {
   const aspectRatio = 9 / 16 // 16:9 aspect ratio, which is typical for videos
-  const [boxWidth, setBoxWidth] = useState(0)
+  const windowWidth = Dimensions.get('window').width
+  const [boxWidth, setBoxWidth] = useState(windowWidth)
+  // Hide video initially on Android and only show it just after the component has rendered, otherwise Android screen animations combined with WebView can cause a crash
+  const [showVideo, setShowVideo] = useState(
+    Platform.OS === 'android' ? false : true,
+  )
   const videoHeight = boxWidth * aspectRatio
   const [useVideoWebpagePlayer, setUseVideoWebpagePlayer] = useState(true)
   const webViewStyle = {
     minHeight: videoHeight,
+    opacity: 0.99, // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/1915
     width: boxWidth,
   }
+
+  useEffect(() => {
+    setTimeout(() => setShowVideo(true), 500)
+  }, [])
 
   if (
     (!videoWebpagePlayerOnly || !useVideoWebpagePlayer) &&
@@ -54,43 +65,48 @@ const Video: FC<VideoProps> = ({
       display="flex"
       marginBottom={marginBottom ?? 0}
       marginTop={marginTop ?? 0}
+      minHeight={videoHeight}
       onLayout={onLayoutEvent => {
-        const { width } = onLayoutEvent.nativeEvent.layout
-        setBoxWidth(width)
+        const newBoxWidth = onLayoutEvent.nativeEvent.layout.width
+        setBoxWidth(newBoxWidth)
       }}
     >
       {/*
        * Use videoWebpagePlayerOnly to show the video inside a small webview (it should look like just a normal video player, not a web page) on the screen they're already on
        * As a fallback if there is a videoWebpage we show the user a placeholder that links to the video in a web view on another screen
        */}
-      {videoWebpagePlayerOnly && useVideoWebpagePlayer ? (
-        <WebView
-          allowsFullscreenVideo
-          allowsInlineMediaPlayback
-          mediaPlaybackRequiresUserAction={false}
-          onError={error => {
-            setUseVideoWebpagePlayer(false)
-            console.error('Error loading video webpage - player only', error)
-          }}
-          source={{ uri: videoWebpagePlayerOnly as string }}
-          style={webViewStyle}
-        />
-      ) : (
-        <Pressable
-          onPress={() =>
-            navigate(videoWebpageScreen as keyof RootStackParamList, {
-              url: videoWebpage as string,
-            })
-          }
-        >
-          <Image
-            alt="Watch video"
-            height={videoHeight}
-            source={VideoPlaceholder}
-            width={boxWidth}
+      {showVideo ? (
+        videoWebpagePlayerOnly && useVideoWebpagePlayer ? (
+          <WebView
+            allowsFullscreenVideo
+            allowsInlineMediaPlayback
+            mediaPlaybackRequiresUserAction={false}
+            onError={error => {
+              setUseVideoWebpagePlayer(false)
+              console.error('Error loading video webpage - player only', error)
+            }}
+            overScrollMode="never" // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/2364
+            removeClippedSubviews // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/2364
+            source={{ uri: videoWebpagePlayerOnly as string }}
+            style={webViewStyle}
           />
-        </Pressable>
-      )}
+        ) : (
+          <Pressable
+            onPress={() =>
+              navigate(videoWebpageScreen as keyof RootStackParamList, {
+                url: videoWebpage as string,
+              })
+            }
+          >
+            <Image
+              alt="Watch video"
+              height={videoHeight}
+              source={VideoPlaceholder}
+              width={boxWidth}
+            />
+          </Pressable>
+        )
+      ) : null}
     </Box>
   )
 }

--- a/app/src/NativeBase/Components/Video.tsx
+++ b/app/src/NativeBase/Components/Video.tsx
@@ -51,7 +51,7 @@ const Video: FC<VideoProps> = ({
   }
 
   useEffect(() => {
-    setTimeout(() => setShowVideo(true), 500)
+    setTimeout(() => setShowVideo(true), 1000)
   }, [])
 
   if (

--- a/app/src/NativeBase/Containers/WebViewContainer.tsx
+++ b/app/src/NativeBase/Containers/WebViewContainer.tsx
@@ -3,8 +3,9 @@
  * Shows a web page containing a page from an external website filling the available height.
  */
 
-import React, { useState } from 'react'
 import { ScrollView } from 'native-base'
+import React, { useEffect, useState } from 'react'
+import { Platform } from 'react-native'
 import WebView from 'react-native-webview'
 
 export interface WebViewRouteParams {
@@ -25,6 +26,18 @@ const WebViewContainer = (props: {
   }
 }) => {
   const [containerHeight, setContainerHeight] = useState(0)
+  // Hide WebView component initially on Android and only show it just after the component has rendered, otherwise Android screen animations can cause it to crash the app
+  const [showWebView, setShowWebView] = useState(
+    Platform.OS === 'android' ? false : true,
+  )
+
+  useEffect(() => {
+    setTimeout(() => setShowWebView(true), 500)
+  }, [])
+  const webViewStyle = {
+    minHeight: containerHeight,
+    opacity: 0.99, // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/1915
+  }
 
   return (
     <ScrollView
@@ -33,15 +46,19 @@ const WebViewContainer = (props: {
         setContainerHeight(height)
       }}
     >
-      <WebView
-        allowsFullscreenVideo
-        allowsInlineMediaPlayback
-        mediaPlaybackRequiresUserAction={false}
-        nestedScrollEnabled
-        scrollEnabled
-        source={{ uri: props.route.params.url }}
-        style={{ minHeight: containerHeight }}
-      />
+      {showWebView && (
+        <WebView
+          allowsFullscreenVideo
+          allowsInlineMediaPlayback
+          mediaPlaybackRequiresUserAction={false}
+          nestedScrollEnabled
+          overScrollMode="never" // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/2364
+          removeClippedSubviews // recommended setting to reduce crashes on Android https://github.com/react-native-webview/react-native-webview/issues/2364
+          scrollEnabled
+          source={{ uri: props.route.params.url }}
+          style={webViewStyle}
+        />
+      )}
     </ScrollView>
   )
 }

--- a/app/src/NativeBase/Containers/WebViewContainer.tsx
+++ b/app/src/NativeBase/Containers/WebViewContainer.tsx
@@ -32,7 +32,7 @@ const WebViewContainer = (props: {
   )
 
   useEffect(() => {
-    setTimeout(() => setShowWebView(true), 500)
+    setTimeout(() => setShowWebView(true), 1000)
   }, [])
   const webViewStyle = {
     minHeight: containerHeight,


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- The project detail screen has been crashing sometimes on Android when it includes a video -- affects at least the emulator running on Linux, but potentially some real Android devices too
- Discovered it was the Android animation when the project detail screen is shown (that slight zoom effect you see) -- if the WebView component is already rendered it crashes the app.  Similar issues have been reported on real devices by others using the react-native-webview.
- Solution proposed is to very slightly delay the rendering of the WebView component (which shows the video) until after the screen has rendered and the Android animation has completed.
- Also added some other settings to the WebView component that are recommended by others who have experienced crashes in Android  with react-native-webview

Fixes # (issue number)

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing locally

- Open a project detail screen that contains a video in your Android emulator

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any unnecessary comments or console logging
- [] I have made corresponding changes to the documentation (if required)
- [] I have addressed accessibility, if needed
- [x] I have followed best practices, e.g. NativeBase approaches and theming
- [] I have checked the app in dark mode, if making front-end design changes
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
