### PR TITLE
Sva 315/flickering colour tag fix

### DIFF
--- a/app/src/NativeBase/Components/ColouredTag.tsx
+++ b/app/src/NativeBase/Components/ColouredTag.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react'
 import { Box, Text, useColorMode } from 'native-base'
-import { getRoleGroupIndex } from '../../Services/modules/projects/roleGroups'
+import { getRoleGroupIndex } from '@/Services/modules/projects/roleGroups'
 
 type ColouredTagProps = {
   title: string
@@ -26,7 +26,7 @@ const ColouredTag = ({ title }: ColouredTagProps) => {
   const coloursToUse = colours[colorMode ?? 'light']
 
   const roleIndex = getRoleGroupIndex(title)
-  let selectedColour
+  let selectedColour = coloursToUse[0]
   if (roleIndex) {
     selectedColour = coloursToUse[roleIndex % coloursToUse.length]
   }

--- a/app/src/NativeBase/Components/ColouredTag.tsx
+++ b/app/src/NativeBase/Components/ColouredTag.tsx
@@ -28,7 +28,7 @@ const ColouredTag = ({ title }: ColouredTagProps) => {
   const roleIndex = getRoleGroupIndex(title)
   let selectedColour
   if (roleIndex) {
-    selectedColour = coloursToUse[roleIndex % 3]
+    selectedColour = coloursToUse[roleIndex % coloursToUse.length]
   }
 
   if (title) {

--- a/app/src/NativeBase/Components/ColouredTag.tsx
+++ b/app/src/NativeBase/Components/ColouredTag.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react'
 import { Box, Text, useColorMode } from 'native-base'
+import { getRoleGroupIndex } from '../../Services/modules/projects/roleGroups'
 
 type ColouredTagProps = {
   title: string
@@ -23,21 +24,23 @@ const ColouredTag = ({ title }: ColouredTagProps) => {
   }
   const { colorMode } = useColorMode()
   const coloursToUse = colours[colorMode ?? 'light']
-  const randomColour =
-    coloursToUse[Math.floor(Math.random() * coloursToUse.length)]
+  // const randomColour = coloursToUse[Math.floor(Math.random() * coloursToUse.length)]
+
+  const roleIndex = getRoleGroupIndex(title)
+  const selectedColour = coloursToUse[0]
 
   if (title) {
     return (
       <Box
         alignSelf="flex-start"
         _dark={{ backgroundColor: 'bg.100' }}
-        _light={{ backgroundColor: randomColour }}
+        _light={{ backgroundColor: selectedColour }}
         rounded="md"
         marginLeft={2}
         maxHeight="xs"
       >
-        <Text _dark={{ color: randomColour }} fontSize="xs">
-          {title}
+        <Text _dark={{ color: selectedColour }} fontSize="xs">
+          {title} {roleIndex}
         </Text>
       </Box>
     )

--- a/app/src/NativeBase/Components/ColouredTag.tsx
+++ b/app/src/NativeBase/Components/ColouredTag.tsx
@@ -24,10 +24,12 @@ const ColouredTag = ({ title }: ColouredTagProps) => {
   }
   const { colorMode } = useColorMode()
   const coloursToUse = colours[colorMode ?? 'light']
-  // const randomColour = coloursToUse[Math.floor(Math.random() * coloursToUse.length)]
 
   const roleIndex = getRoleGroupIndex(title)
-  const selectedColour = coloursToUse[0]
+  let selectedColour
+  if (roleIndex) {
+    selectedColour = coloursToUse[roleIndex % 3]
+  }
 
   if (title) {
     return (
@@ -40,7 +42,7 @@ const ColouredTag = ({ title }: ColouredTagProps) => {
         maxHeight="xs"
       >
         <Text _dark={{ color: selectedColour }} fontSize="xs">
-          {title} {roleIndex}
+          {title}
         </Text>
       </Box>
     )

--- a/app/src/Services/modules/projects/roleGroups.ts
+++ b/app/src/Services/modules/projects/roleGroups.ts
@@ -198,10 +198,8 @@ export const roleGroups: RoleGroup[] = [
   },
 ]
 
-// Gets an index for NativeBase/Components/ColouredTag.tsx
-export const getRoleGroupIndex = (
-  possibleRoleName: string,
-): number | undefined => {
+// Gets an index for of the Role Group (used for NativeBase/Components/ColouredTag.tsx)
+export const getRoleGroupIndex = (possibleRoleName: string): number => {
   const fuse = new Fuse(roleGroups, {
     keys: ['roleNames'],
   })

--- a/app/src/Services/modules/projects/roleGroups.ts
+++ b/app/src/Services/modules/projects/roleGroups.ts
@@ -198,11 +198,13 @@ export const roleGroups: RoleGroup[] = [
   },
 ]
 
-const getRoleColour = (possibleRoleColour: string): Number | undefined => {
+export const getRoleGroupIndex = (
+  possibleRoleName: string,
+): number | undefined => {
   const fuse = new Fuse(roleGroups, {
     keys: ['roleNames'],
   })
-  const fuseResults = fuse.search(possibleRoleColour)
+  const fuseResults = fuse.search(possibleRoleName)
 
   for (const fuseResult of fuseResults) {
     for (const role of fuseResult.item.roleNames) {

--- a/app/src/Services/modules/projects/roleGroups.ts
+++ b/app/src/Services/modules/projects/roleGroups.ts
@@ -3,6 +3,8 @@
  * These are used e.g. for searching projects
  */
 
+import Fuse from 'fuse.js'
+
 export interface RoleGroup {
   groupName: RoleGroupName
   roleNames: string[]
@@ -195,3 +197,17 @@ export const roleGroups: RoleGroup[] = [
     ],
   },
 ]
+
+const getRoleColour = (possibleRoleColour: string): Number | undefined => {
+  const fuse = new Fuse(roleGroups, {
+    keys: ['roleNames'],
+  })
+  const fuseResults = fuse.search(possibleRoleColour)
+
+  for (const fuseResult of fuseResults) {
+    for (const role of fuseResult.item.roleNames) {
+      return Number(role)
+    }
+  }
+  return undefined
+}

--- a/app/src/Services/modules/projects/roleGroups.ts
+++ b/app/src/Services/modules/projects/roleGroups.ts
@@ -198,6 +198,7 @@ export const roleGroups: RoleGroup[] = [
   },
 ]
 
+// Gets an index for NativeBase/Components/ColouredTag.tsx
 export const getRoleGroupIndex = (
   possibleRoleName: string,
 ): number | undefined => {
@@ -206,10 +207,9 @@ export const getRoleGroupIndex = (
   })
   const fuseResults = fuse.search(possibleRoleName)
 
-  for (const fuseResult of fuseResults) {
-    for (const role of fuseResult.item.roleNames) {
-      return Number(role)
-    }
+  if (!Array.isArray(fuseResults) || !fuseResults.length) {
+    return 0
+  } else {
+    return fuseResults[0].refIndex
   }
-  return undefined
 }


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

### Problem
- Issue of flickering ColouredTag on the project list when scrolling through projects, and on the project detail screen.  (This is because  the ColouredTag component chooses a colour randomly, which can change each time React re-renders the component.)

### Solution
- Addition of a function in `app/src/Services/modules/projects/roleGroups.ts` called 'getRoleGroupIndex' that takes a role group name and returns a number. Uses that number in the `app/src/NativeBase/Components/ColouredTag.tsx` file to use that index number for the background colour selection, rather than a random colour like previous implementation. This number has to be coerced to be within the range of the colours, which is currently an array of 3 colour items, hence use of the remainder (%) operator on line 31.

Fixes # SVA-315

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing locally

- Run on your emulator/device in this branch, and ensure the tags are consistent on reload, and do not flicker, in either light or dark mode.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any unnecessary comments or console logging
- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have addressed accessibility, if needed
- [x] I have followed best practices, e.g. NativeBase approaches and theming
- [x] I have checked the app in dark mode, if making front-end design changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
