### PR TITLE
SVA-297 | Stop projects list and projects search results being cut off at bottom

### DIFF
--- a/app/src/NativeBase/Containers/ListContainer.tsx
+++ b/app/src/NativeBase/Containers/ListContainer.tsx
@@ -9,6 +9,7 @@
 
 import { Heading, VStack } from 'native-base'
 import React, { useEffect, useState } from 'react'
+import { Dimensions } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/native'
 import { EventSearch } from '@/Containers/EventSearchContainer'
@@ -24,6 +25,7 @@ import List, {
 import ProjectFilterSort from '@/Components/Project/ProjectFilterSort'
 import TopOfApp from '@/NativeBase/Components/TopOfApp'
 import { navigate, RootStackParamList } from '@/Navigators/utils'
+import { heightOfTopOfAppPlusBottomNav } from '@/Utils/Layout'
 import { capitaliseFirstLetter } from '@/Utils/Text'
 
 import SegmentedPicker, {
@@ -112,6 +114,7 @@ const ListContainer = (props: {
     } as ListScreens,
     search: searchScreens,
   }
+  const windowHeight = Dimensions.get('window').height
 
   const projectListOptions = ['all', 'saved', 'my'].map(
     option =>
@@ -274,7 +277,12 @@ const ListContainer = (props: {
         showSearchButton
         onSearchButtonPress={() => navigate(screens.search[params.type], '')}
       />
-      <VStack paddingBottom="2" alignItems="center" space={4} padding={4}>
+      <VStack
+        alignItems="center"
+        maxHeight={windowHeight - heightOfTopOfAppPlusBottomNav}
+        space={4}
+        padding={4}
+      >
         <Heading size="sm">Projects List</Heading>
         <SegmentedPicker options={projectListOptions} />
 

--- a/app/src/NativeBase/Containers/SearchResultsContainer.tsx
+++ b/app/src/NativeBase/Containers/SearchResultsContainer.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   View,
 } from 'native-base'
+import { Dimensions } from 'react-native'
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons'
 import { EventSearch } from '@/Containers/EventSearchContainer'
 import List, {
@@ -64,6 +65,9 @@ const SearchResultsContainer = (props: {
     [ListType.Events]: 'Events' as keyof RootStackParamList,
     [ListType.Projects]: 'Projects' as keyof RootStackParamList,
   } as ListScreens
+  const headerAndSpacingHeight = 100
+  const [searchResultsTextHeight, setSearchResultsTextHeight] = useState(0)
+  const windowHeight = Dimensions.get('window').height
 
   const clearSearch = () => {
     navigate(screens[params.type], {
@@ -84,7 +88,8 @@ const SearchResultsContainer = (props: {
           _dark={{ backgroundColor: 'bg.100' }}
           justifyContent="space-between"
           onLayout={onLayoutEvent => {
-            const { width } = onLayoutEvent.nativeEvent.layout
+            const { height, width } = onLayoutEvent.nativeEvent.layout
+            setSearchResultsTextHeight(height)
             setBoxWidth(width)
           }}
           paddingRight="1"
@@ -120,7 +125,12 @@ const SearchResultsContainer = (props: {
       </View>
 
       {Boolean(params.search?.results) && (
-        <View padding="4">
+        <View
+          maxHeight={
+            windowHeight - headerAndSpacingHeight - searchResultsTextHeight
+          }
+          padding="4"
+        >
           <List
             data={params.search?.results as Events | Projects}
             mode={ListDisplayMode.Search}

--- a/app/src/Utils/Layout.ts
+++ b/app/src/Utils/Layout.ts
@@ -1,0 +1,1 @@
+export const heightOfTopOfAppPlusBottomNav = 180


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- Part of the last card in the projects list, and in projects search results, was being cut off making the last project on both screens partially unreadable (not great)
- Fixed this on both screens, when tested on iOS
- I feel like there should be a better way to do this using flexbox, but I haven't been able to figure it out, so this seems like an acceptable solution for now (assuming it works on Android too)

Fixes # SVA-297

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing locally

- Scroll to the bottom of the projects list, you should be able to see all of the last card (it shouldn't be cut off)
- Do a projects search, again scroll to the bottom of the projects list, you should be able to see all of the last card (it shouldn't be cut off)
- It would be good if someone with an Android phone can test this

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any unnecessary comments or console logging
- [] I have made corresponding changes to the documentation (if required)
- [] I have addressed accessibility, if needed
- [] I have followed best practices, e.g. NativeBase approaches and theming
- [] I have checked the app in dark mode, if making front-end design changes
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
