### PR TITLE
Switch API manual deployment to the right GitHub Action

### DIFF
--- a/.github/workflows/cd_api.yml
+++ b/.github/workflows/cd_api.yml
@@ -5,6 +5,7 @@ on:
     - main
     paths:
       - "api/**"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, edited]
     paths:
       - "api/**"
-  workflow_dispatch:
+
 jobs:
   test:
     name: Tests

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -155,7 +155,7 @@ If you need access to update secrets or make changes on AWS, reach out on [volun
 
 1. Go to our repo's [GitHub Actions page](https://github.com/Scottish-Tech-Army/Volunteer-app/actions)
 
-2. Choose **Continuous Integration - API** from the left-hand menu
+2. Choose **Deploy to Elastic Beanstalk** from the left-hand menu
 
 3. Above the list of workflow runs, select the **Run workflow** dropdown.
 


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- In my last PR I added the option to deploy the API manually... but I put it in the wrong GitHub Action file 🤦‍♂️ (I put it in the one that runs the API tests, not the API deployment).   This corrects that.
- We need this in order to be able to manually deploy the API in situations where we need to deploy it but the API code hasn't changed (which is what usually triggers the deploy).  For example: the environment variables for the API server are updated (which is the case at the moment - so that we can get project register interest messages to go to the right Slack channel).

Fixes # SVA-371

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Testing locally

N/A

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have removed any unnecessary comments or console logging
- [x] I have made corresponding changes to the documentation (if required)
- [] I have addressed accessibility, if needed
- [] I have followed best practices, e.g. NativeBase approaches and theming
- [] I have checked the app in dark mode, if making front-end design changes
- [] If updating the front-end app, I have updated version numbers to prepare for me to [deploy the updated app](DEPLOYMENT.md#app-deployment)
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
