### PR TITLE
SVA-373 | Stop API crashing if database returns no results, improve API deployment docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -44,7 +44,11 @@ There are also settings in the main Expo config file `app/app.config.ts` -- look
 
 **As a general rule you're strongly encouraged to deploy changes as part of any pull request that updates the front-end app** by following the steps below. **But we also just need to be careful not to hit the 15 deployments (30 builds)) limit,** so if there has been a high frequency of approved pull requests this month or your pull request is only a very minor change to the front-end app, you might not want to update the app version and do a new deployment.  If you're not sure, check [how many builds have already been done this month](https://expo.dev/accounts/scottishtecharmy/settings/billing) (and if you're still unsure ask the team on Slack).
 
+### Screenshots
+
 1. If you're making major design/functionality changes/additions, consider updating the screenshots we use in the Google Play Store and App Store. Store screenshots in the `screenshots/app` directory and you'll need to upload them manually in the Google Play and App Store admin consoles.
+
+### Pull request
 
 2. In the pull request for the changes you're making (e.g. a new app feature), before you submit the PR for review, update the `version` number in `app/package.json`. Normally for minor features/fixes, just update the last part of the version number (e.g. `"1.0.24"` becomes `"1.0.25"`).
 
@@ -66,7 +70,7 @@ There are also settings in the main Expo config file `app/app.config.ts` -- look
 
 6. Go ahead and merge your pull request into the `main` branch.
 
-## Build the Android version
+### Build the Android version
 
 7. In the `app` directory run `npm run build-android` (it's the same command if you are creating a build either for internal testing or for production - releasing the app to the public)
 
@@ -82,7 +86,7 @@ There are also settings in the main Expo config file `app/app.config.ts` -- look
 
 8. Once the build is complete, if you get a message asking *Install and run the Android build on an emulator?* say **no**
 
-## Submit to the Google Play Store
+### Submit to the Google Play Store
 
 You've created an Android build and it's stored in the cloud with EAS.  Now we need to submit it to the Google Play Store.
 
@@ -96,7 +100,7 @@ You've created an Android build and it's stored in the cloud with EAS.  Now we n
 
 13. If you have an Android phone, download the updated version of the app ([see instructions](README.md#updating-to-the-latest-version-of-the-app)) and double check it's all working as expected.
 
-## Build the iOS version
+### Build the iOS version
 
 14. In the `app` directory run `npm run build-ios` (it's the same command if you are creating a build either for TestFlight internal testing or for production - releasing the app to the public)
 
@@ -112,7 +116,7 @@ You've created an Android build and it's stored in the cloud with EAS.  Now we n
 
 18. Wait for the build process to complete
 
-## Submit to TestFlight / the App Store
+### Submit to TestFlight / the App Store
 
 You've created an iOS build and it's stored in the cloud with EAS.  Now we need to submit it to TestFlight / the App Store.
 
@@ -130,6 +134,12 @@ You've created an iOS build and it's stored in the cloud with EAS.  Now we need 
 
 # API deployment on AWS
 
+## Pull requests
+
+Each time you update API code, before you submit your pull request for review, update the `version` number in `api/package.json`. Normally for minor features/fixes, just update the last part of the version number (e.g. `"1.0.24"` becomes `"1.0.25"`).
+
+Updating the version number helps us keep track of which version of the API is running on the server, [it's used by Bugsnag when errors are reported.](API_DEVELOPMENT.md#logging-errors)
+
 ## Automatic deployment with GitHub Actions
 
 **API deployment is automatic whenever a Pull Request is merged into the `main` branch on GitHub -- you shouldn't need to do any manual deployment steps with the API.**
@@ -144,6 +154,8 @@ Note: If environment variables have changed, the entire `api/.env` file should b
 - `BUGSNAG_API_KEY` should not usually be in your local .env file, but must be included on the production server
 - `SLACK_CHANNEL_VOLUNTEER_PROJECT_INTEREST` should be different on the production server
 - `SLACK_SECRET_WEBHOOK_INITIAL_TRIAGE` should not usually be in your local .env file, but must be included on the production server
+
+> After you have added the updated .env values to GitHub Secrets, **if you amended your local .env file make sure you reset it back to the values you had before** for local development (e.g. `AIRTABLE_PROJECTS_RESOURCES_CACHE_TABLE` should be the test table name, not the production table name etc -- check all the the variables mentioned in the list above).
 
 > Make sure the .env file you copy and paste from is all correctly formatted too: there should be no spaces before and after `=` signs, string values should be inside double quotes `"`, e.g. `BUGSNAG_API_KEY="abc123def456hij7890xxxxxxxx"`
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,8 @@ Please delete options that are not relevant
 - [] I have addressed accessibility, if needed
 - [] I have followed best practices, e.g. NativeBase approaches and theming
 - [] I have checked the app in dark mode, if making front-end design changes
-- [] If updating the front-end app, I have updated version numbers to prepare for me to [deploy the updated app](DEPLOYMENT.md#app-deployment)
+- [] If updating the front-end app, I have updated app version codes/numbers to prepare for me to [deploy the updated app](DEPLOYMENT.md#app-deployment)
+- [] If updating the API, I have updated the API version number to prepare for me to [deploy the updated API](DEPLOYMENT.md#api-deployment-on-aws)
 - [] My changes generate no new warnings
 - [] I have added tests that prove my fix is effective or that my feature works
 - [] New and existing unit tests pass locally with my changes

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volunteer-app-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "RESTful API to surface the data required for the Volunteer App.",
   "main": "app.js",
   "scripts": {

--- a/api/routes/projects.js
+++ b/api/routes/projects.js
@@ -6,10 +6,12 @@ const projectsHelper = require('../helpers/projects');
 const router = express.Router();
 const routesHelper = require('../helpers/routes');
 
-router.get('/', async (req, res) => {
+router.get('/', async (req, res) => await getAllProjectsHandler(req, res));
+
+const getAllProjectsHandler = async (req, res) => {
   const projectsResources = await airTable.getAllRecords(airTable.projectsResourcesCacheTable());
 
-  if (projectsResources.error) {
+  if (projectsResources && projectsResources.error) {
     routesHelper.sendError(
       res,
       `Database connection error: ${airTable.connectionErrorMessage()}`,
@@ -32,7 +34,7 @@ router.get('/', async (req, res) => {
   );
 
   res.status(200).send(projectsResourcesFormatted);
-});
+};
 
 router.get('/single', async (req, res) => {
   const projectItKey = req.query.it;
@@ -119,6 +121,7 @@ const projectRegisterInterestHandler = async (req, res) => {
 };
 
 module.exports = {
+  getAllProjectsHandler,
   projectsApi: router,
   projectRegisterInterestHandler,
 };

--- a/api/routes/projects.js
+++ b/api/routes/projects.js
@@ -18,6 +18,15 @@ router.get('/', async (req, res) => {
     return;
   }
 
+  if (!projectsResources?.length) {
+    routesHelper.sendError(
+      res,
+      'Could not get projects from database',
+    );
+
+    return;
+  }
+
   const projectsResourcesFormatted = projectsResources.map((projectResource) =>
     projectsHelper.formatProjectResourceFromAirTable(projectResource),
   );


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- A couple of small API fixes to get things ready for the app to go public:
- Stop the API crashing if the AirTable database returns no projects results (this has happened when @kelsiesmurphy was running the API locally on his machine -- it's probably a rare case, but this makes the API more stable, we never want it to crash in production)
- Added tests for this
- Also spotted that a few API docs need minor improvements around deployment instructions

Fixes # SVA-373

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Testing locally

- Run your local API server and check that the all projects endpoint `/v1/projects` (e.g. `https://xxxxxxxx.serveo.net/v1/projects`) works as normal

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have removed any unnecessary comments or console logging
- [x] I have made corresponding changes to the documentation (if required)
- [] I have addressed accessibility, if needed
- [] I have followed best practices, e.g. NativeBase approaches and theming
- [] I have checked the app in dark mode, if making front-end design changes
- [] If updating the front-end app, I have updated version numbers to prepare for me to [deploy the updated app](DEPLOYMENT.md#app-deployment)
- [] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
