### PR TITLE
SVA-370 & SVA-374 | Email input usability fix, secondary button accessibility fix

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -25,7 +25,7 @@ module.exports = {
         backgroundColor: '#ffffff',
       },
       package: 'org.scottishtecharmy.volunteerapp',
-      versionCode: 14,
+      versionCode: 15,
     },
     ios: {
       bundleIdentifier: 'org.scottishtecharmy.volunteerapp',
@@ -34,7 +34,7 @@ module.exports = {
         NSCalendarsUsageDescription:
           "The app will show tech/volunteering-related events that the user might be interested in. The user can choose to attend an event - if so, the app needs access to the user's calendar in order to add an event.",
       },
-      buildNumber: '16',
+      buildNumber: '17',
       supportsTablet: true,
     },
     web: {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "STA Volunteer app",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {

--- a/app/src/NativeBase/Components/Forms/SecondaryButton.tsx
+++ b/app/src/NativeBase/Components/Forms/SecondaryButton.tsx
@@ -16,7 +16,7 @@ interface SecondaryButtonProps {
 const SecondaryButton: FC<SecondaryButtonProps> = ({ onPress, text }) => {
   return (
     <Button
-      backgroundColor="bg.secondary"
+      backgroundColor="bg.100"
       borderColor="primary.100"
       borderWidth="2"
       onPress={onPress}

--- a/app/src/NativeBase/Components/Forms/SecondaryButton.tsx
+++ b/app/src/NativeBase/Components/Forms/SecondaryButton.tsx
@@ -16,14 +16,9 @@ interface SecondaryButtonProps {
 const SecondaryButton: FC<SecondaryButtonProps> = ({ onPress, text }) => {
   return (
     <Button
+      backgroundColor="bg.secondary"
       borderColor="primary.100"
       borderWidth="2"
-      _dark={{
-        bg: 'bgDarkMode',
-      }}
-      _light={{
-        bg: 'bg.secondary',
-      }}
       onPress={onPress}
       _pressed={{ bg: 'primary.20' }}
       _text={{ color: 'primary.100' }}

--- a/app/src/NativeBase/Components/Forms/TextInputControl.tsx
+++ b/app/src/NativeBase/Components/Forms/TextInputControl.tsx
@@ -72,6 +72,22 @@ const TextInputControl: FC<TextInputControlProps> = ({
     | 'username-new'
     | 'off'
     | undefined
+  let inputMode = 'text' as
+    | 'none'
+    | 'text'
+    | 'decimal'
+    | 'numeric'
+    | 'tel'
+    | 'search'
+    | 'email'
+    | 'url'
+  let keyboardType = 'default' as
+    | 'default'
+    | 'email-address'
+    | 'numeric'
+    | 'phone-pad'
+    | 'number-pad'
+    | 'decimal-pad'
   let textContentType = 'none' as
     | 'none'
     | 'URL'
@@ -106,6 +122,8 @@ const TextInputControl: FC<TextInputControlProps> = ({
   switch (type) {
     case 'email':
       autoComplete = 'email'
+      inputMode = 'email'
+      keyboardType = 'email-address'
       textContentType = 'emailAddress'
       break
     case 'firstName':
@@ -138,6 +156,8 @@ const TextInputControl: FC<TextInputControlProps> = ({
       <Input
         autoCapitalize={autoCapitalize}
         autoComplete={autoComplete}
+        inputMode={inputMode}
+        keyboardType={keyboardType}
         onBlur={onBlur}
         size="sm"
         onChangeText={onChange}


### PR DESCRIPTION
- [Description](#description)
  - [Type of change](#type-of-change)
- [Testing locally](#testing-locally)
- [Checklist](#checklist)

# Description

- Email input field on Android 13 was not showing @ or . characters, which isn't helpful to the user - updated the settings for any email input so it should show an appropriate keyboard.
- The Google Play Store automatically checks our app for accessibility issues (the report isn’t perfect, but some of it is helpful).  Spotted that in dark mode, the colour contrast on the secondary button (currently only used for ‘No thanks’ on modal on the Welcome screen when asking user to opt in to bug reporting) is not accessible with a dark background, so using off-white background colour for both colour modes.  (Not the designers' fault - we added this modal outside of the normal design process.)

Fixes # SVA-370 & SVA-374

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing locally

- Would be good if someone with an Android can test the project register interest form (I think this should work, but am on an iPhone so can't test it myself) -- you don't need to submit the form, just tap on the email address input and see if you get an appropriate keyboard (should include @ and . characters)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have removed any unnecessary comments or console logging
- [] I have made corresponding changes to the documentation (if required)
- [x] I have addressed accessibility, if needed
- [x] I have followed best practices, e.g. NativeBase approaches and theming
- [x] I have checked the app in dark mode, if making front-end design changes
- [x] If updating the front-end app, I have updated version numbers to prepare for me to [deploy the updated app](DEPLOYMENT.md#app-deployment)
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
