### PR TITLE
SVA-415 fix register interest api

### DIFF
--- a/api/__tests__/routes/projects.test.js
+++ b/api/__tests__/routes/projects.test.js
@@ -4,12 +4,14 @@ const axios = require('axios');
 const dayjs = require('dayjs');
 const { faker } = require('@faker-js/faker');
 const nock = require('nock');
-const { getAllProjectsHandler, projectRegisterInterestHandler } = require('../../routes/projects');
+const {
+  getAllProjectsHandler,
+  projectRegisterInterestHandler,
+} = require('../../routes/projects');
 const projectsHelper = require('../../helpers/projects');
 const projectsTestData = require('../../__test-data__/projects');
 const request = require('supertest');
 const routesHelper = require('../../helpers/routes');
-const slackService = require('../../services/slack');
 
 axios.defaults.adapter = require('axios/lib/adapters/http');
 
@@ -25,7 +27,9 @@ describe('Test the projects api', () => {
     );
 
     // Mock dependencies
-    const requestMock = nock('http://localhost:3000').get('/projects').reply(200, fakeProjectResources);
+    const requestMock = nock('http://localhost:3000')
+      .get('/projects')
+      .reply(200, fakeProjectResources);
 
     // Run test
     const response = await axios.get('http://localhost:3000/projects');
@@ -45,7 +49,9 @@ describe('Test the projects api', () => {
     const numberOfProjects = faker.number.int({ min: 10, max: 30 });
     const fakeProjectResources = [];
     for (let i = 0; i < numberOfProjects; i++) {
-      fakeProjectResources.push(projectsTestData.fakeAirTableProjectResource(true));
+      fakeProjectResources.push(
+        projectsTestData.fakeAirTableProjectResource(true),
+      );
     }
 
     // Mock dependencies
@@ -66,9 +72,13 @@ describe('Test the projects api', () => {
     // Run test
     await getAllProjectsHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetAllRecordsSpy).toHaveBeenCalledTimes(1);
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(numberOfProjects);
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).toHaveBeenCalledTimes(numberOfProjects);
     expect(responseMock.status).toHaveBeenCalledTimes(1);
     expect(responseMock.status).toHaveBeenCalledWith(200);
     expect(responseMock.send).toHaveBeenCalledTimes(1);
@@ -97,7 +107,7 @@ describe('Test the projects api', () => {
       .mockImplementation(() => ({ error: 'Some error message' }));
     const routesHelperSendErrorSpy = jest
       .spyOn(routesHelper, 'sendError')
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     const projectsHelperFormatProjectResourceFromAirTableSpy = jest
       .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
       .mockImplementation(fakeProjectResource => fakeProjectResource);
@@ -109,10 +119,14 @@ describe('Test the projects api', () => {
     // Run test
     await getAllProjectsHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetAllRecordsSpy).toHaveBeenCalledTimes(1);
     expect(routesHelperSendErrorSpy).toHaveBeenCalledTimes(1);
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(0);
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).toHaveBeenCalledTimes(0);
     expect(responseMock.status).toHaveBeenCalledTimes(0);
     expect(responseMock.send).toHaveBeenCalledTimes(0);
 
@@ -140,7 +154,7 @@ describe('Test the projects api', () => {
       .mockImplementation(() => undefined);
     const routesHelperSendErrorSpy = jest
       .spyOn(routesHelper, 'sendError')
-      .mockImplementation(() => { });
+      .mockImplementation(() => {});
     const projectsHelperFormatProjectResourceFromAirTableSpy = jest
       .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
       .mockImplementation(fakeProjectResource => fakeProjectResource);
@@ -152,10 +166,14 @@ describe('Test the projects api', () => {
     // Run test
     await getAllProjectsHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetAllRecordsSpy).toHaveBeenCalledTimes(1);
     expect(routesHelperSendErrorSpy).toHaveBeenCalledTimes(1);
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(0);
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).toHaveBeenCalledTimes(0);
     expect(responseMock.status).toHaveBeenCalledTimes(0);
     expect(responseMock.send).toHaveBeenCalledTimes(0);
 
@@ -177,7 +195,9 @@ describe('Test the projects api', () => {
 
     // Mock dependencies
     const singleProjectsMock = nock('http://localhost:3000')
-      .get(`/projects/single?res=${fakeProjectResource.res_id}&it=${fakeProjectResource.it_key}`)
+      .get(
+        `/projects/single?res=${fakeProjectResource.res_id}&it=${fakeProjectResource.it_key}`,
+      )
       .reply(200, fakeProjectResource);
 
     // Run test
@@ -209,7 +229,9 @@ describe('Test the projects api', () => {
 
     // Mock dependencies
     const requestMock = nock('http://localhost:3000')
-      .post(`/projects/single/register-interest?res=${fakeProjectResource.res_id}&it=${fakeProjectResource.it_key}`)
+      .post(
+        `/projects/single/register-interest?res=${fakeProjectResource.res_id}&it=${fakeProjectResource.it_key}`,
+      )
       .reply(200, responseData);
 
     // Run test
@@ -222,11 +244,12 @@ describe('Test the projects api', () => {
     expect(response.data).toEqual(responseData);
   });
 
-  test('projectRegisterInterestHandler calls AirTable and Slack and returns a response', async () => {
+  test('projectRegisterInterestHandler calls AirTable and returns a response', async () => {
     // Set up fake test data
     const fakeProjectsResourcesCacheTableName = faker.lorem.word();
     const fakeProjectsRegisterInterestTableName = faker.lorem.word();
-    const fakeProjectResource = projectsTestData.fakeAirTableProjectResource(true);
+    const fakeProjectResource =
+      projectsTestData.fakeAirTableProjectResource(true);
     const fakeRequest = {
       query: {
         it: fakeProjectResource.it_key,
@@ -257,9 +280,6 @@ describe('Test the projects api', () => {
     const projectsHelperFormatProjectResourceFromAirTableSpy = jest
       .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
       .mockImplementation(() => fakeProjectResource);
-    const slackServicePostMessageSpy = jest
-      .spyOn(slackService, 'postMessage')
-      .mockImplementation(() => ({ data: 'success' }));
     const responseMock = {
       send: jest.fn(() => responseMock),
       status: jest.fn(() => responseMock),
@@ -268,27 +288,38 @@ describe('Test the projects api', () => {
     // Run test
     await projectRegisterInterestHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(fakeProjectsResourcesCacheTableName, {
-      it_key: fakeRequest.query.it,
-      res_id: fakeRequest.query.res,
-    });
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(
+      fakeProjectsResourcesCacheTableName,
+      {
+        it_key: fakeRequest.query.it,
+        res_id: fakeRequest.query.res,
+      },
+    );
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).toHaveBeenCalledTimes(1);
 
-    expect(slackServicePostMessageSpy).toHaveBeenCalledTimes(1);
-
-    expect(airTableHelperProjectsRegisterInterestCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(
+      airTableHelperProjectsRegisterInterestCacheTableSpy,
+    ).toHaveBeenCalledTimes(1);
     expect(airTableHelperCreateRecordSpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperCreateRecordSpy).toHaveBeenCalledWith(fakeProjectsRegisterInterestTableName, {
-      'Name': `${fakeRequest.body.firstName} ${fakeRequest.body.lastName}`,
-      'Create date': dayjs().format('YYYY-MM-DD'),
-      'Available from': fakeRequest.body.availableFrom,
-      'Project name': fakeProjectResource.name,
-      'Role': fakeProjectResource.role,
-      'Peer Support': fakeRequest.body.lookingForPeerSupport ? 'Yes' : 'No',
-      'email': fakeRequest.body.email,
-    }, 'sta');
+    expect(airTableHelperCreateRecordSpy).toHaveBeenCalledWith(
+      fakeProjectsRegisterInterestTableName,
+      {
+        Name: `${fakeRequest.body.firstName} ${fakeRequest.body.lastName}`,
+        'Create date': dayjs().format('YYYY-MM-DD'),
+        'Available from': fakeRequest.body.availableFrom,
+        'Project name': fakeProjectResource.name,
+        Role: fakeProjectResource.role,
+        'Peer Support': fakeRequest.body.lookingForPeerSupport ? 'Yes' : 'No',
+        email: fakeRequest.body.email,
+      },
+      'sta',
+    );
 
     expect(responseMock.status).toHaveBeenCalledTimes(1);
     expect(responseMock.status).toHaveBeenCalledWith(200);
@@ -300,13 +331,13 @@ describe('Test the projects api', () => {
     airTableHelperGetRecordByQuerySpy.mockRestore();
     airTableHelperCreateRecordSpy.mockRestore();
     projectsHelperFormatProjectResourceFromAirTableSpy.mockRestore();
-    slackServicePostMessageSpy.mockRestore();
   });
 
   test('projectRegisterInterestHandler returns an error if project cannot be found', async () => {
     // Set up fake test data
     const fakeTableName = faker.lorem.word();
-    const fakeProjectResource = projectsTestData.fakeAirTableProjectResource(true);
+    const fakeProjectResource =
+      projectsTestData.fakeAirTableProjectResource(true);
     const fakeRequest = {
       query: {
         it: fakeProjectResource.it_key,
@@ -322,7 +353,9 @@ describe('Test the projects api', () => {
     };
 
     // Mock dependencies
-    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { });
+    const consoleErrorSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {});
     const airTableHelperProjectsResourcesCacheTableSpy = jest
       .spyOn(airTable, 'projectsResourcesCacheTable')
       .mockImplementation(() => fakeTableName);
@@ -332,9 +365,6 @@ describe('Test the projects api', () => {
     const projectsHelperFormatProjectResourceFromAirTableSpy = jest
       .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
       .mockImplementation(() => fakeProjectResource);
-    const slackServicePostMessageSpy = jest
-      .spyOn(slackService, 'postMessage')
-      .mockImplementation(() => ({ data: 'success' }));
     const responseMock = {
       send: jest.fn(() => responseMock),
       status: jest.fn(() => responseMock),
@@ -343,14 +373,20 @@ describe('Test the projects api', () => {
     // Run test
     await projectRegisterInterestHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(fakeTableName, {
-      it_key: fakeRequest.query.it,
-      res_id: fakeRequest.query.res,
-    });
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).not.toHaveBeenCalled();
-    expect(slackServicePostMessageSpy).not.toHaveBeenCalled();
+    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(
+      fakeTableName,
+      {
+        it_key: fakeRequest.query.it,
+        res_id: fakeRequest.query.res,
+      },
+    );
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).not.toHaveBeenCalled();
     expect(responseMock.status).toHaveBeenCalledTimes(1);
     expect(responseMock.status).toHaveBeenCalledWith(400);
     expect(responseMock.send).toHaveBeenCalledTimes(1);
@@ -361,13 +397,13 @@ describe('Test the projects api', () => {
     airTableHelperProjectsResourcesCacheTableSpy.mockRestore();
     airTableHelperGetRecordByQuerySpy.mockRestore();
     projectsHelperFormatProjectResourceFromAirTableSpy.mockRestore();
-    slackServicePostMessageSpy.mockRestore();
   });
 
   test('projectRegisterInterestHandler returns an error if data is missing from the request', async () => {
     // Set up fake test data
     const fakeTableName = faker.lorem.word();
-    const fakeProjectResource = projectsTestData.fakeAirTableProjectResource(true);
+    const fakeProjectResource =
+      projectsTestData.fakeAirTableProjectResource(true);
     const fakeRequest = {
       query: {
         it: fakeProjectResource.it_key,
@@ -377,7 +413,9 @@ describe('Test the projects api', () => {
     };
 
     // Mock dependencies
-    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { });
+    const consoleErrorSpy = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {});
     const airTableHelperProjectsResourcesCacheTableSpy = jest
       .spyOn(airTable, 'projectsResourcesCacheTable')
       .mockImplementation(() => fakeTableName);
@@ -387,9 +425,6 @@ describe('Test the projects api', () => {
     const projectsHelperFormatProjectResourceFromAirTableSpy = jest
       .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
       .mockImplementation(() => fakeProjectResource);
-    const slackServicePostMessageSpy = jest
-      .spyOn(slackService, 'postMessage')
-      .mockImplementation(() => ({ data: 'success' }));
     const responseMock = {
       send: jest.fn(() => responseMock),
       status: jest.fn(() => responseMock),
@@ -398,14 +433,20 @@ describe('Test the projects api', () => {
     // Run test
     await projectRegisterInterestHandler(fakeRequest, responseMock);
 
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
+    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(
+      1,
+    );
     expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(fakeTableName, {
-      it_key: fakeRequest.query.it,
-      res_id: fakeRequest.query.res,
-    });
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(1);
-    expect(slackServicePostMessageSpy).not.toHaveBeenCalled();
+    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(
+      fakeTableName,
+      {
+        it_key: fakeRequest.query.it,
+        res_id: fakeRequest.query.res,
+      },
+    );
+    expect(
+      projectsHelperFormatProjectResourceFromAirTableSpy,
+    ).toHaveBeenCalledTimes(1);
     expect(responseMock.status).toHaveBeenCalledTimes(1);
     expect(responseMock.status).toHaveBeenCalledWith(400);
     expect(responseMock.send).toHaveBeenCalledTimes(1);
@@ -416,68 +457,5 @@ describe('Test the projects api', () => {
     airTableHelperProjectsResourcesCacheTableSpy.mockRestore();
     airTableHelperGetRecordByQuerySpy.mockRestore();
     projectsHelperFormatProjectResourceFromAirTableSpy.mockRestore();
-    slackServicePostMessageSpy.mockRestore();
-  });
-
-  test('projectRegisterInterestHandler returns an error if Slack service returns an error', async () => {
-    // Set up fake test data
-    const fakeTableName = faker.lorem.word();
-    const fakeProjectResource = projectsTestData.fakeAirTableProjectResource(true);
-    const fakeRequest = {
-      query: {
-        it: fakeProjectResource.it_key,
-        res: fakeProjectResource.res_id,
-      },
-      body: {
-        firstName: faker.person.firstName(),
-        lastName: faker.person.lastName(),
-        email: faker.internet.email(),
-        lookingForPeerSupport: faker.datatype.boolean(),
-        availableFrom: '2022-12-31',
-      },
-    };
-    const slackErrorResponse = { error: 'Some error message' };
-
-    // Mock dependencies
-    const consoleErrorSpy = jest.spyOn(global.console, 'error').mockImplementation(() => { });
-    const airTableHelperProjectsResourcesCacheTableSpy = jest
-      .spyOn(airTable, 'projectsResourcesCacheTable')
-      .mockImplementation(() => fakeTableName);
-    const airTableHelperGetRecordByQuerySpy = jest
-      .spyOn(airTable, 'getRecordByQuery')
-      .mockImplementation(() => fakeProjectResource);
-    const projectsHelperFormatProjectResourceFromAirTableSpy = jest
-      .spyOn(projectsHelper, 'formatProjectResourceFromAirTable')
-      .mockImplementation(() => fakeProjectResource);
-    const slackServicePostMessageSpy = jest
-      .spyOn(slackService, 'postMessage')
-      .mockImplementation(() => slackErrorResponse);
-    const responseMock = {
-      send: jest.fn(() => responseMock),
-      status: jest.fn(() => responseMock),
-    };
-
-    // Run test
-    await projectRegisterInterestHandler(fakeRequest, responseMock);
-
-    expect(airTableHelperProjectsResourcesCacheTableSpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledTimes(1);
-    expect(airTableHelperGetRecordByQuerySpy).toHaveBeenCalledWith(fakeTableName, {
-      it_key: fakeRequest.query.it,
-      res_id: fakeRequest.query.res,
-    });
-    expect(projectsHelperFormatProjectResourceFromAirTableSpy).toHaveBeenCalledTimes(1);
-    expect(slackServicePostMessageSpy).toHaveBeenCalledTimes(1);
-    expect(responseMock.status).toHaveBeenCalledTimes(1);
-    expect(responseMock.status).toHaveBeenCalledWith(400);
-    expect(responseMock.send).toHaveBeenCalledTimes(1);
-    expect(responseMock.send).toHaveBeenCalledWith(slackErrorResponse);
-
-    // Clean up
-    consoleErrorSpy.mockRestore();
-    airTableHelperProjectsResourcesCacheTableSpy.mockRestore();
-    airTableHelperGetRecordByQuerySpy.mockRestore();
-    projectsHelperFormatProjectResourceFromAirTableSpy.mockRestore();
-    slackServicePostMessageSpy.mockRestore();
   });
 });

--- a/api/routes/projects.js
+++ b/api/routes/projects.js
@@ -1,7 +1,6 @@
 const airTable = require('../helpers/airTable');
 const dayjs = require('dayjs');
 const express = require('express');
-const slackService = require('../services/slack');
 const projectsHelper = require('../helpers/projects');
 const router = express.Router();
 const routesHelper = require('../helpers/routes');
@@ -9,7 +8,9 @@ const routesHelper = require('../helpers/routes');
 router.get('/', async (req, res) => await getAllProjectsHandler(req, res));
 
 const getAllProjectsHandler = async (req, res) => {
-  const projectsResources = await airTable.getAllRecords(airTable.projectsResourcesCacheTable());
+  const projectsResources = await airTable.getAllRecords(
+    airTable.projectsResourcesCacheTable(),
+  );
 
   if (projectsResources && projectsResources.error) {
     routesHelper.sendError(
@@ -21,15 +22,12 @@ const getAllProjectsHandler = async (req, res) => {
   }
 
   if (!projectsResources?.length) {
-    routesHelper.sendError(
-      res,
-      'Could not get projects from database',
-    );
+    routesHelper.sendError(res, 'Could not get projects from database');
 
     return;
   }
 
-  const projectsResourcesFormatted = projectsResources.map((projectResource) =>
+  const projectsResourcesFormatted = projectsResources.map(projectResource =>
     projectsHelper.formatProjectResourceFromAirTable(projectResource),
   );
 
@@ -40,10 +38,13 @@ router.get('/single', async (req, res) => {
   const projectItKey = req.query.it;
   const resourceId = req.query.res;
 
-  const projectResource = await airTable.getRecordByQuery(airTable.projectsResourcesCacheTable(), {
-    it_key: projectItKey,
-    res_id: resourceId,
-  });
+  const projectResource = await airTable.getRecordByQuery(
+    airTable.projectsResourcesCacheTable(),
+    {
+      it_key: projectItKey,
+      res_id: resourceId,
+    },
+  );
 
   if (!projectResource || projectResource.error) {
     routesHelper.sendError(
@@ -54,28 +55,28 @@ router.get('/single', async (req, res) => {
     return;
   }
 
-  const projectResourceFormatted = projectsHelper.formatProjectResourceFromAirTable(projectResource);
+  const projectResourceFormatted =
+    projectsHelper.formatProjectResourceFromAirTable(projectResource);
 
   res.status(200).send(projectResourceFormatted);
 });
 
-/*
- * TODO: When authentication has been set up, we need to:
- *  - Protect this API route, by only allowing requests from authenticated users (otherwise anyone who knows this route exists can post messages to the inital triage Slack channel)
- *  - Get the user's name and email from their user record instead
- *  - Save in a database that this user has expressed interest in this project
- *
- */
-router.post('/single/register-interest', async (req, res) => await projectRegisterInterestHandler(req, res));
+router.post(
+  '/single/register-interest',
+  async (req, res) => await projectRegisterInterestHandler(req, res),
+);
 
 const projectRegisterInterestHandler = async (req, res) => {
   const projectItKey = req.query.it;
   const resourceId = req.query.res;
 
-  const projectResource = await airTable.getRecordByQuery(airTable.projectsResourcesCacheTable(), {
-    it_key: projectItKey,
-    res_id: resourceId,
-  });
+  const projectResource = await airTable.getRecordByQuery(
+    airTable.projectsResourcesCacheTable(),
+    {
+      it_key: projectItKey,
+      res_id: resourceId,
+    },
+  );
 
   if (!projectResource || projectResource.error) {
     routesHelper.sendError(
@@ -86,49 +87,52 @@ const projectRegisterInterestHandler = async (req, res) => {
     return;
   }
 
-  const projectResourceFormatted = projectsHelper.formatProjectResourceFromAirTable(projectResource);
+  const projectResourceFormatted =
+    projectsHelper.formatProjectResourceFromAirTable(projectResource);
 
-  const dataExpected = ['availableFrom', 'email', 'firstName', 'lastName', 'lookingForPeerSupport'];
+  const dataExpected = [
+    'availableFrom',
+    'email',
+    'firstName',
+    'lastName',
+    'lookingForPeerSupport',
+  ];
 
   const dataNotProvided = [];
 
   for (const dataItemExpected of dataExpected) {
-    if (!req.body?.hasOwnProperty(dataItemExpected)) dataNotProvided.push(dataItemExpected);
+    if (!req.body?.hasOwnProperty(dataItemExpected))
+      dataNotProvided.push(dataItemExpected);
   }
 
   if (dataNotProvided.length) {
-    routesHelper.sendError(res, `These properties were missing from your request: ${dataNotProvided.join(', ')}`);
+    routesHelper.sendError(
+      res,
+      `These properties were missing from your request: ${dataNotProvided.join(
+        ', ',
+      )}`,
+    );
 
     return;
   }
 
   const fullName = `${req.body.firstName} ${req.body.lastName}`;
 
-  const slackResponse = await slackService.postMessage(
-    process.env.SLACK_CHANNEL_VOLUNTEER_PROJECT_INTEREST,
-    `🎉🎉🎉 Hurray! We've got a new volunteer interested in *${projectResourceFormatted.name}* for *${projectResourceFormatted.client
-    }*
-
-    ➡️ *Role*  ${projectResourceFormatted.role}
-    👤 *Volunteer*  ${fullName}
-    ✉️ *Email*  ${req.body.email}
-    🧑‍🤝‍🧑 *Looking for peer support?*  ${req.body.lookingForPeerSupport ? 'Yes' : 'No'}
-    📅 *Available from*  ${dayjs(req.body.availableFrom, 'YYYY-MM-DD').format('D MMMM YYYY')}
-
-    Please get in touch with them to follow up`,
+  const airTableCreateRecordSuccess = await airTable.createRecord(
+    airTable.projectsRegisterInterestTable(),
+    {
+      Name: fullName,
+      'Create date': dayjs().format('YYYY-MM-DD'),
+      'Available from': req.body.availableFrom,
+      'Project name': projectResourceFormatted.name,
+      Role: projectResourceFormatted.role,
+      'Peer Support': req.body.lookingForPeerSupport ? 'Yes' : 'No',
+      email: req.body.email,
+    },
+    'sta',
   );
 
-  const airTableCreateRecordSuccess = await airTable.createRecord(airTable.projectsRegisterInterestTable(), {
-    'Name': fullName,
-    'Create date': dayjs().format('YYYY-MM-DD'),
-    'Available from': req.body.availableFrom,
-    'Project name': projectResourceFormatted.name,
-    'Role': projectResourceFormatted.role,
-    'Peer Support': req.body.lookingForPeerSupport ? 'Yes' : 'No',
-    'email': req.body.email,
-  }, 'sta');
-
-  res.status((slackResponse.data && airTableCreateRecordSuccess) ? 200 : 400).send(slackResponse);
+  res.status(airTableCreateRecordSuccess ? 200 : 400).send({ data: 'success' });
 };
 
 module.exports = {


### PR DESCRIPTION
# Description

Removes the code that posts message to slack when someone registers interest in the app.

This used a slack integration which was turned off when we downgraded to free version of slack, and since the slack call happens before airtable we have no record of volunteer interest. The long-term solution to slack notifications is the use something like Zapier which we have already have installed, the change here just removes the current integration so we can fix the API.

There is some noise in the changeset since I have auto-formatting turned on in my IDE, I used the prettier config in #198 to reduce this to a minimum.

Fixes SVA-415

## Type of change

Please delete options that are not relevant

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change(fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing locally

Tested `http://localhost:3000/v1/projects/single/register-interest` endpoint running locally, didn't fall over.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (_we need to talk about this one..._)
- [x] I have removed any unnecessary comments or console logging
- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have addressed accessibility, if needed
- [ ] I have followed best practices, e.g. NativeBase approaches and theming
- [ ] I have checked the app in dark mode, if making front-end design changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the version numbers in `package.json` files in the [app](DEPLOYMENT.md#app-deployment) and/or [api](DEPLOYMENT.md#api-deployment-on-aws) directories as needed
